### PR TITLE
feat: add `setPrompt` to the terminal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ An object that's being passed to every command function & returned by `initTermi
 | `start()`  | Starts a "foreground process": user input is blocked and command prompt never appears. |  |
 | `stop()`  | Stops "foreground process". |  |
 | `type(text, speed, callback)`  | Prints a text with "typing" effect. Hides and blocks user input while typing. | `text` - String, text to be printed. `speed` - integer, miliseconds. The higher the number, the slower. `callback` - function, gets executed when the process is finished. |
+| `setPrompt()`  | Set terminal prompt | `newPrompt` - String   |
 
 ### settings object
 

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -8,6 +8,7 @@ import { attachKeyboardListener } from '../helpers/keyboard'
 import { dispatchEvent, TerminalEvent } from '../helpers/events'
 import createHelp from '../helpers/help'
 import loadStyle from '../helpers/loadStyle'
+import setPrompt from './prompt'
 
 const initTerminal = ({
   host,
@@ -38,11 +39,12 @@ const initTerminal = ({
     input,
 
     print: (content: string, isCommand = false) =>
-      print(content, isCommand, commandContainer, input, prompt),
+      print(content, isCommand, commandContainer, input, settings),
     run: (cmd: string) => evalCommand(cmd, terminal),
     start: () => startProcess(terminal),
     stop: () => stopProcess(terminal),
-    type: (text: string, speed = 60, callback) => typeText(text, speed, terminal, callback)
+    type: (text: string, speed = 60, callback) => typeText(text, speed, terminal, callback),
+    setPrompt: (newPrompt: string) => setPrompt(newPrompt, inputContainer, settings)
   }
   if (enableHelp) {
     terminal.settings.commands.help = createHelp(terminal)

--- a/src/api/print.ts
+++ b/src/api/print.ts
@@ -1,8 +1,9 @@
 import { create } from '../helpers/dom'
+import { TerminalSettings } from '../types'
 
 // Prints a new line in the terminal
-const print = (content: string, isCommand: boolean, commandContainer: HTMLElement, input: HTMLElement, prompt: string) => {
-  const line = create('p', undefined, isCommand ? prompt : content)
+const print = (content: string, isCommand: boolean, commandContainer: HTMLElement, input: HTMLElement, settings: TerminalSettings) => {
+  const line = create('p', undefined, isCommand ? settings.prompt : content)
   if (isCommand) {
     const cmd = create('span', 'terminal-command', content)
     line.append(cmd)

--- a/src/api/prompt.ts
+++ b/src/api/prompt.ts
@@ -1,0 +1,10 @@
+import { TerminalSettings } from '../types'
+
+// Set a new terminal prompt
+const setPrompt = (prompt: string, inputContainer: HTMLElement, settings: TerminalSettings) => {
+  settings.prompt = prompt
+  const promptContainer = inputContainer.querySelector('span') as HTMLElement
+  promptContainer.textContent = prompt
+}
+
+export default setPrompt

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -12,5 +12,6 @@ export type TerminalInstance = {
   start: () => void
   stop: () => void
   type: (text: string, speed?: number, callback?: () => void) => void
+  setPrompt: (newPrompt: string) => void
   isProcessRunning: boolean
 }


### PR DESCRIPTION
## Description

Exposes an ability to set a new prompt from the terminal API. 
It was kind of possible previously by modifying the `settings.prompt` in a command directly, but it was incorrectly passed to the `print` so it would only display the original prompt from the init process.

## Pre-review checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if required)
- [X] My contribution is awesome
