### PR TITLE
patch: set inner HTML instead of textContent for the prompt

### DIFF
--- a/src/api/prompt.ts
+++ b/src/api/prompt.ts
@@ -4,7 +4,7 @@ import { TerminalSettings } from '../types'
 const setPrompt = (prompt: string, inputContainer: HTMLElement, settings: TerminalSettings) => {
   settings.prompt = prompt
   const promptContainer = inputContainer.querySelector('span') as HTMLElement
-  promptContainer.textContent = prompt
+  promptContainer.innerHTML = prompt
 }
 
 export default setPrompt


### PR DESCRIPTION
## Description

Follow-up for https://github.com/mkrl/ttty/pull/37 to allow for more flexibility.

## Pre-review checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if required)
- [x] My contribution is awesome
