### PR TITLE
feat: make TerminalEvent available to import externally

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import initTerminal from './api/init'
+import { TerminalEvent } from './helpers/events'
 
-export { initTerminal }
+export { initTerminal, TerminalEvent }


### PR DESCRIPTION
## Description

Event enum can now be imported in the external code when using ttty.


## Pre-review checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if required)
- [X] My contribution is awesome
