### PR TITLE
feat: add an ability to initialize with custom history

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ An object that's being passed to every command function & returned by `initTermi
 | `enableHelp`: boolean | Toggle default `help` command that lists all the available commands and their descriptions. | true |
 | `prompt`: string | Terminal prompt | '$: ' |
 | `historyLength`: number | A maximum amount of commands that can be stored in the terminal history | 50 |
+| `history`: string[] | A default value for terminal history (can be used to preserve history across sessions) | [] |
 | `commands`: object | `commands` object |  |
 
 ### commands object

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -15,6 +15,7 @@ const initTerminal = ({
   welcomeMessage,
   prompt = '$: ',
   historyLength = 50,
+  history = [],
   enableHelp = true,
   commands
 }: TerminalSettings) => {
@@ -30,7 +31,7 @@ const initTerminal = ({
   const { commandContainer, input, inputContainer } = buildTree(host, prompt)
 
   const terminal: TerminalInstance = {
-    history: [],
+    history,
     lastHistoryIndex: 0,
     isProcessRunning: false,
     settings,

--- a/src/types/terminalSettings.ts
+++ b/src/types/terminalSettings.ts
@@ -6,5 +6,6 @@ export type TerminalSettings = {
   welcomeMessage?: string,
   prompt?: string
   historyLength?: number
+  history?: string[],
   enableHelp?: boolean
 }


### PR DESCRIPTION
## Description

Terminal history can now be preserved somewhere (up to the user) and passed down to `initTerminal` as `history: string[]`

Fixes #40 

## Pre-review checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if required)
- [X] My contribution is awesome
