### PR TITLE
feat: promise-based `type()` API that now supports treating text as command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ initTerminal(settings)
 
 An object that's being passed to every command function & returned by `initTerminal`
 
-| Method  | Description | Parameters |
-| ------------- | ------------- | ------------- |
-| `print(text, isCommand)`  | Prints a given text in the terminal (accepts raw HTML)  | `text` - String, `isCommand` - Boolean, optional, defaults to false. Count given string as a command (displays prompt & syntax highlight) |
-| `run(text)`  | Emulates a command execution in a terminal (acts the same way as a user would have typed and pressed Enter)  | `text` - String |
-| `start()`  | Starts a "foreground process": user input is blocked and command prompt never appears. |  |
-| `stop()`  | Stops "foreground process". |  |
-| `type(text, speed, callback)`  | Prints a text with "typing" effect. Hides and blocks user input while typing. | `text` - String, text to be printed. `speed` - integer, miliseconds. The higher the number, the slower. `callback` - function, gets executed when the process is finished. |
-| `setPrompt()`  | Set terminal prompt | `newPrompt` - String   |
+| Method                                             | Description                                                                                                                                                       | Parameters                                                                                                                                |
+|----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `print(text, isCommand)`                           | Prints a given text in the terminal (accepts raw HTML)                                                                                                            | `text` - String, `isCommand` - Boolean, optional, defaults to false. Count given string as a command (displays prompt & syntax highlight) |
+| `run(text)`                                        | Emulates a command execution in a terminal (acts the same way as a user would have typed and pressed Enter)                                                       | `text` - String                                                                                                                           |
+| `start()`                                          | Starts a "foreground process": user input is blocked and command prompt never appears.                                                                            |                                                                                                                                           |
+| `stop()`                                           | Stops "foreground process".                                                                                                                                       |                                                                                                                                           |
+| `type(text, speed, isCommand) => Promise<boolean>` | Prints a text with "typing" effect. Hides and blocks user input while typing. Resolves to either `true` or `false` depending on process interruption by the user. | `text` - String, text to be printed. `speed` - integer, miliseconds. The higher the number, the slower. `isCommand` - Boolean, optional, defaults to false. Count given string as a command (displays prompt & syntax highlight)                                  |
+| `setPrompt()`                                      | Set terminal prompt                                                                                                                                               | `newPrompt` - String                                                                                                                      |
 
 ### settings object
 

--- a/preview/main.ts
+++ b/preview/main.ts
@@ -33,11 +33,24 @@ const terminal = initTerminal({
       func: (terminal) => {
         terminal.print('Downloading more RAM...')
         terminal.print('Press Ctrl + C if you think you have enough RAM')
-        terminal.type('............................................', 160, () => {
-          if (terminal.isProcessRunning) {
-            terminal.print('Successfully downloaded 42gb of RAM!')
-          }
-        })
+        terminal.type('............................................', 100)
+          .then((finished) => {
+            if (finished) {
+              terminal.print('Successfully downloaded 42gb of RAM!')
+            }
+          })
+      }
+    },
+    enqueue: {
+      name: 'enqueue',
+      description: 'pretend like someone else is typing in the terminal',
+      func: (terminal) => {
+        terminal.type('test', 70, true)
+          .then((finished) => {
+            if (finished) {
+              terminal.run('test')
+            }
+          })
       }
     },
     color: {

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -44,7 +44,7 @@ const initTerminal = ({
     run: (cmd: string) => evalCommand(cmd, terminal),
     start: () => startProcess(terminal),
     stop: () => stopProcess(terminal),
-    type: (text: string, speed = 60, callback) => typeText(text, speed, terminal, callback),
+    type: (text: string, speed = 60, isCommand) => typeText(text, speed, terminal, isCommand),
     setPrompt: (newPrompt: string) => setPrompt(newPrompt, inputContainer, settings)
   }
   if (enableHelp) {

--- a/src/api/typeText.ts
+++ b/src/api/typeText.ts
@@ -2,22 +2,27 @@ import { TerminalInstance } from '../types'
 import { startProcess, stopProcess } from './process'
 import { create } from '../helpers/dom'
 
-const typeText = (text: string, speed: number, terminal: TerminalInstance, callback?: () => void) => {
+const typeText = (text: string, speed: number, terminal: TerminalInstance, isCommand?: boolean) => new Promise<boolean>(resolve => {
   startProcess(terminal)
-  const line = create('p')
+  const line = create('p', undefined, isCommand ? terminal.settings.prompt : '')
+  const cmd = create('span', 'terminal-command', '')
+  if (isCommand) {
+    line.append(cmd)
+  }
   terminal.commandContainer.append(line)
   let i = 0
+  const typeTarget = isCommand ? cmd : line
   const type = () => {
     if (i < text.length && terminal.isProcessRunning) {
-      line.innerHTML += text.charAt(i)
+      typeTarget.innerHTML += text.charAt(i)
       i++
       setTimeout(type, speed)
     } else {
-      callback && callback()
       stopProcess(terminal)
+      resolve(i === text.length)
     }
   }
   setTimeout(type, speed)
-}
+})
 
 export default typeText

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -11,7 +11,7 @@ export type TerminalInstance = {
   run: (cmd: string) => void
   start: () => void
   stop: () => void
-  type: (text: string, speed?: number, callback?: () => void) => void
+  type: (text: string, speed?: number, isCommand?: boolean) => Promise<boolean>
   setPrompt: (newPrompt: string) => void
   isProcessRunning: boolean
 }


### PR DESCRIPTION
## Description

Convert existing `type()` API to be promise-based.
Instead of `callback` you can now pass a new argument `isCommand` (acts in the same way as in `print`, useful for terminal demos where you would create an effect of someone else typing the command).

The function now returns a promise resolving to `true` or `false` depending on user input interruption.

You might want to convert existing usages of `type` with callbacks in a similar matter:

### Before
```typescript
        terminal.type('text', 120, () => {
          if (terminal.isProcessRunning) {
            terminal.print('Typing finished')
          }
        })
```
### After
```typescript
        terminal.type('text', 120)
          .then((finished) => {
            if (finished) {
              terminal.print('Typing finished')
            }
          })
```
or
```typescript
        const finished = await terminal.type('text', 120)
        if (finished) {
            terminal.print('Typing finished')
        }
```


## Pre-review checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if required)
- [x] My contribution is awesome
